### PR TITLE
Cifti

### DIFF
--- a/pybest/bookkeeping.py
+++ b/pybest/bookkeeping.py
@@ -87,7 +87,7 @@ def find_exp_parameters(cfg, logger):
     """ Extracts experimental parameters. """
 
     hemi, space = cfg['hemi'], cfg['space']
-    if iscifti == 'y':
+    if cfg['iscifti'] == 'y':
         space_idf = f'LR*.dtseries.nii' if 'fs' in space else 'desc-preproc_bold.nii.gz'
     else:
         space_idf = f'hemi-{hemi}*.func.gii' if 'fs' in space else 'desc-preproc_bold.nii.gz'
@@ -129,7 +129,7 @@ def find_exp_parameters(cfg, logger):
             these_task = []
             for this_ses in these_ses:
                 if this_ses is None:  # only single session!
-                    if iscifti == 'y':
+                    if cfg['iscifti'] == 'y':
                         tmp = glob(op.join(
                             cfg['fprep_dir'],
                             f'sub-{this_sub}',
@@ -144,7 +144,7 @@ def find_exp_parameters(cfg, logger):
                             f"*space-{cfg['space']}*_{space_idf}"
                         ))
                 else:
-                    if iscifti == 'y':
+                    if cfg['iscifti'] == 'y':
                         tmp = glob(op.join(
                             cfg['fprep_dir'],
                             f'sub-{this_sub}',
@@ -181,7 +181,7 @@ def find_exp_parameters(cfg, logger):
             these_task = []
             for this_ses in these_ses:
                 if this_ses is None:
-                    if iscifti == 'y':
+                    if cfg['iscifti'] == 'y':
                         tmp = glob(op.join(
                             cfg['fprep_dir'],
                             f'sub-{this_sub}',
@@ -196,7 +196,7 @@ def find_exp_parameters(cfg, logger):
                             f"*task-{cfg['task']}_*_space-{cfg['space']}*_{space_idf}"
                         ))
                 else:
-                    if iscifti == 'y':
+                    if cfg['iscifti'] == 'y':
                         tmp = glob(op.join(
                             cfg['fprep_dir'],
                             f'sub-{this_sub}',
@@ -238,7 +238,7 @@ def find_data(cfg, logger):
         ses = '*'  # wilcard for globbing across sessions
 
     # idf = identifier for files
-    if iscifti == 'y':
+    if cfg['iscifti'] == 'y':
         idf = f'LR*.dtseries.nii' if 'fs' in space else 'desc-preproc_bold.nii.gz'
     else:
         idf = f'hemi-{hemi}*.func.gii' if 'fs' in space else 'desc-preproc_bold.nii.gz'
@@ -249,7 +249,7 @@ def find_data(cfg, logger):
         ffunc_dir = op.join(fprep_dir, f'sub-{sub}', 'func')
     else:
         ffunc_dir = op.join(fprep_dir, f'sub-{sub}', f'ses-{ses}', 'func')
-    if iscifti == 'y':
+    if cfg['iscifti'] == 'y':
         funcs = sorted(glob(op.join(ffunc_dir, f'*task-{task}_*space-{space}_?{idf}')))
     else:
         funcs = sorted(glob(op.join(ffunc_dir, f'*task-{task}_*space-{space}_{idf}')))

--- a/pybest/bookkeeping.py
+++ b/pybest/bookkeeping.py
@@ -250,7 +250,7 @@ def find_data(cfg, logger):
     else:
         ffunc_dir = op.join(fprep_dir, f'sub-{sub}', f'ses-{ses}', 'func')
     if cfg['iscifti'] == 'y':
-        funcs = sorted(glob(op.join(ffunc_dir, f'*task-{task}_*space-{space}*{idf}')))
+        funcs = sorted(glob(op.join(ffunc_dir, f'*task-{task}_*space-{space}{idf}')))
     else:
         funcs = sorted(glob(op.join(ffunc_dir, f'*task-{task}_*space-{space}_{idf}')))
     if not funcs:

--- a/pybest/bookkeeping.py
+++ b/pybest/bookkeeping.py
@@ -250,7 +250,7 @@ def find_data(cfg, logger):
     else:
         ffunc_dir = op.join(fprep_dir, f'sub-{sub}', f'ses-{ses}', 'func')
     if cfg['iscifti'] == 'y':
-        funcs = sorted(glob(op.join(ffunc_dir, f'*task-{task}_*space-{space}_?{idf}')))
+        funcs = sorted(glob(op.join(ffunc_dir, f'*task-{task}_*space-{space}*{idf}')))
     else:
         funcs = sorted(glob(op.join(ffunc_dir, f'*task-{task}_*space-{space}_{idf}')))
     if not funcs:

--- a/pybest/bookkeeping.py
+++ b/pybest/bookkeeping.py
@@ -88,7 +88,7 @@ def find_exp_parameters(cfg, logger):
 
     hemi, space = cfg['hemi'], cfg['space']
     if cfg['iscifti'] == 'y':
-        space_idf = f'LR*.dtseries.nii' if 'fs' in space else 'desc-preproc_bold.nii.gz'
+        space_idf = f'*.dtseries.nii' if 'fs' in space else 'desc-preproc_bold.nii.gz'
     else:
         space_idf = f'hemi-{hemi}*.func.gii' if 'fs' in space else 'desc-preproc_bold.nii.gz'
 
@@ -239,7 +239,7 @@ def find_data(cfg, logger):
 
     # idf = identifier for files
     if cfg['iscifti'] == 'y':
-        idf = f'LR*.dtseries.nii' if 'fs' in space else 'desc-preproc_bold.nii.gz'
+        idf = f'*.dtseries.nii' if 'fs' in space else 'desc-preproc_bold.nii.gz'
     else:
         idf = f'hemi-{hemi}*.func.gii' if 'fs' in space else 'desc-preproc_bold.nii.gz'
 

--- a/pybest/bookkeeping.py
+++ b/pybest/bookkeeping.py
@@ -260,7 +260,7 @@ def find_data(cfg, logger):
         )
 
     if cfg['iscifti'] == 'y':
-        confs = sorted(glob(op.join(ffunc_dir, f'*task-{task}_*desc - confounds_timeseries.tsv')))
+        confs = sorted(glob(op.join(ffunc_dir, f'*task-{task}_*desc-confounds_timeseries.tsv')))
     else:
         confs = sorted(glob(op.join(ffunc_dir, f'*task-{task}_*desc-confounds_regressors.tsv')))
 

--- a/pybest/bookkeeping.py
+++ b/pybest/bookkeeping.py
@@ -258,8 +258,11 @@ def find_data(cfg, logger):
             "Could not find fMRI data with the following parameters:\n"
             f"sub-{sub}, ses-{ses}, task-{task}, space-{space}_{idf}"
         )
-    
-    confs = sorted(glob(op.join(ffunc_dir, f'*task-{task}_*desc-confounds_regressors.tsv')))
+
+    if cfg['iscifti'] == 'y':
+        confs = sorted(glob(op.join(ffunc_dir, f'*task-{task}_*desc - confounds_timeseries.tsv')))
+    else:
+        confs = sorted(glob(op.join(ffunc_dir, f'*task-{task}_*desc-confounds_regressors.tsv')))
 
     # Find event files, which should be in the BIDS dir
     bids_dir = cfg['bids_dir']

--- a/pybest/cli.py
+++ b/pybest/cli.py
@@ -39,7 +39,7 @@ from .signal_model import run_signal_processing
 @click.option('--hemi', type=click.Choice(['L', 'R']), default='L', show_default=True, help='Hemisphere to process (only relevant when dealing with surface space data)')
 @click.option('--iscifti', type=click.Choice(['y', 'n']), default='n', show_default=True, help='Choose "y" if files in cifti format')
 @click.option('--mode', type=click.Choice(['surface', 'subcortex', 'all']), default='surface', show_default=True, help='When using cifti file, choose whether to process surface, subcortex or both')
-@click.option('--skip-tr', default=0, type=click.INT, show_default=True, help='Number of TRs to skip (in case of unwanted peak in data)')
+@click.option('--skip-tr', nargs=2, multiple=True, default=[(None,0)], type=(click.STRING,click.INT), show_default=True, help='Number of TRs to skip (in case of unwanted peak in data) for a specific file -> [file] [tr]')
 @click.option('--confounds-filter', '-cf', default=[None], multiple=True, type=click.STRING, help='Confounds to select (multiple as list) - partial strings are enough (regex)')
 # 3. Preproc options
 @click.option('--gm-thresh', default=0., show_default=True, help='Threshold for gray-matter mask (if 0, Fmriprep brain masks are used)')  # maybe use a "mask" option

--- a/pybest/cli.py
+++ b/pybest/cli.py
@@ -40,7 +40,7 @@ from .signal_model import run_signal_processing
 @click.option('--iscifti', type=click.Choice(['y', 'n']), default='n', show_default=True, help='Choose "y" if files in cifti format')
 @click.option('--mode', type=click.Choice(['surface', 'subcortex', 'all']), default='surface', show_default=True, help='When using cifti file, choose whether to process surface, subcortex or both')
 @click.option('--skip-tr', default=0, type=click.INT, show_default=True, help='Number of TRs to skip (in case of unwanted peak in data)')
-@click.option('--confounds-filter', type=click.STRING, help='Confounds to select (multiple as list) - partial strings are enough (regex)')
+@click.option('--confounds-filter', default=None, type=click.STRING, help='Confounds to select (multiple as list) - partial strings are enough (regex)')
 # 3. Preproc options
 @click.option('--gm-thresh', default=0., show_default=True, help='Threshold for gray-matter mask (if 0, Fmriprep brain masks are used)')  # maybe use a "mask" option
 @click.option('--slice-time-ref', type=click.FLOAT, default=0.5, show_default=True, help='Slice to adjust event onsets to (depends on slice-time correction)')

--- a/pybest/cli.py
+++ b/pybest/cli.py
@@ -106,7 +106,7 @@ def main(fprep_dir, bids_dir, atlas_file, left_id, right_id, subc_id, out_dir, s
                 
                 # Some bookkeeping
                 if iscifti == 'y':
-                    space_idf = f'fsLR' if 'fs' in space else space
+                    space_idf = space
                 else:
                     space_idf = f'{space}_hemi-{hemi}' if 'fs' in space else space
 

--- a/pybest/cli.py
+++ b/pybest/cli.py
@@ -38,6 +38,7 @@ from .signal_model import run_signal_processing
 @click.option('--space', default='T1w', show_default=True, help='Output space of data to be processed (e.g., T1w, MNI152NLin2009cAsym)')
 @click.option('--hemi', type=click.Choice(['L', 'R']), default='L', show_default=True, help='Hemisphere to process (only relevant when dealing with surface space data)')
 @click.option('--iscifti', type=click.Choice(['y', 'n']), default='n', show_default=True, help='Choose "y" if files in cifti format')
+@click.option('--mode', type=click.Choice(['surface', 'subcortex', 'all']), default='surface', show_default=True, help='When using cifti file, choose whether to process surface, subcortex or both')
 # 3. Preproc options
 @click.option('--gm-thresh', default=0., show_default=True, help='Threshold for gray-matter mask (if 0, Fmriprep brain masks are used)')  # maybe use a "mask" option
 @click.option('--slice-time-ref', type=click.FLOAT, default=0.5, show_default=True, help='Slice to adjust event onsets to (depends on slice-time correction)')
@@ -73,7 +74,7 @@ from .signal_model import run_signal_processing
 @click.option('--save-mgz', is_flag=True, help='Save surface files as mgz instead of npy files')
 @click.option('--verbose', default='INFO', type=click.Choice(['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']), show_default=True, help='Verbosity level')
 def main(fprep_dir, bids_dir, atlas_file, left_id, right_id, subc_id, out_dir, start_from, ricor_dir, subject, session, pool_sessions, task, space, hemi,
-         iscifti, gm_thresh, slice_time_ref, high_pass_type, high_pass, trial_filter, skip_noiseproc, noise_source, decomp, n_comps,
+         iscifti, mode, gm_thresh, slice_time_ref, high_pass_type, high_pass, trial_filter, skip_noiseproc, noise_source, decomp, n_comps,
          noiseproc_type, cv_repeats, cv_splits, regularize_n_comps, argmax_percent, skip_signalproc, signalproc_type, contrast,
          single_trial_id, hrf_model, single_trial_noise_model, regularize_hrf_model, single_trial_model, pattern_units, uncorrelation,
          smoothing_fwhm, n_cpus, save_all, save_mgz, verbose):

--- a/pybest/cli.py
+++ b/pybest/cli.py
@@ -40,7 +40,7 @@ from .signal_model import run_signal_processing
 @click.option('--iscifti', type=click.Choice(['y', 'n']), default='n', show_default=True, help='Choose "y" if files in cifti format')
 @click.option('--mode', type=click.Choice(['surface', 'subcortex', 'all']), default='surface', show_default=True, help='When using cifti file, choose whether to process surface, subcortex or both')
 @click.option('--skip-tr', default=0, type=click.INT, show_default=True, help='Number of TRs to skip (in case of unwanted peak in data)')
-@click.option('--confounds-filter', default=None, type=click.STRING, help='Confounds to select (multiple as list) - partial strings are enough (regex)')
+@click.option('--confounds-filter', '-cf', default=[None], multiple=True, type=click.STRING, help='Confounds to select (multiple as list) - partial strings are enough (regex)')
 # 3. Preproc options
 @click.option('--gm-thresh', default=0., show_default=True, help='Threshold for gray-matter mask (if 0, Fmriprep brain masks are used)')  # maybe use a "mask" option
 @click.option('--slice-time-ref', type=click.FLOAT, default=0.5, show_default=True, help='Slice to adjust event onsets to (depends on slice-time correction)')

--- a/pybest/cli.py
+++ b/pybest/cli.py
@@ -39,6 +39,7 @@ from .signal_model import run_signal_processing
 @click.option('--hemi', type=click.Choice(['L', 'R']), default='L', show_default=True, help='Hemisphere to process (only relevant when dealing with surface space data)')
 @click.option('--iscifti', type=click.Choice(['y', 'n']), default='n', show_default=True, help='Choose "y" if files in cifti format')
 @click.option('--mode', type=click.Choice(['surface', 'subcortex', 'all']), default='surface', show_default=True, help='When using cifti file, choose whether to process surface, subcortex or both')
+@click.option('--skip-tr', default=0, type=click.INT, show_default=True, help='Number of TRs to skip (in case of unwanted peak in data)')
 # 3. Preproc options
 @click.option('--gm-thresh', default=0., show_default=True, help='Threshold for gray-matter mask (if 0, Fmriprep brain masks are used)')  # maybe use a "mask" option
 @click.option('--slice-time-ref', type=click.FLOAT, default=0.5, show_default=True, help='Slice to adjust event onsets to (depends on slice-time correction)')
@@ -74,7 +75,7 @@ from .signal_model import run_signal_processing
 @click.option('--save-mgz', is_flag=True, help='Save surface files as mgz instead of npy files')
 @click.option('--verbose', default='INFO', type=click.Choice(['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']), show_default=True, help='Verbosity level')
 def main(fprep_dir, bids_dir, atlas_file, left_id, right_id, subc_id, out_dir, start_from, ricor_dir, subject, session, pool_sessions, task, space, hemi,
-         iscifti, mode, gm_thresh, slice_time_ref, high_pass_type, high_pass, trial_filter, skip_noiseproc, noise_source, decomp, n_comps,
+         iscifti, mode, skip_tr, gm_thresh, slice_time_ref, high_pass_type, high_pass, trial_filter, skip_noiseproc, noise_source, decomp, n_comps,
          noiseproc_type, cv_repeats, cv_splits, regularize_n_comps, argmax_percent, skip_signalproc, signalproc_type, contrast,
          single_trial_id, hrf_model, single_trial_noise_model, regularize_hrf_model, single_trial_model, pattern_units, uncorrelation,
          smoothing_fwhm, n_cpus, save_all, save_mgz, verbose):

--- a/pybest/cli.py
+++ b/pybest/cli.py
@@ -40,6 +40,7 @@ from .signal_model import run_signal_processing
 @click.option('--iscifti', type=click.Choice(['y', 'n']), default='n', show_default=True, help='Choose "y" if files in cifti format')
 @click.option('--mode', type=click.Choice(['surface', 'subcortex', 'all']), default='surface', show_default=True, help='When using cifti file, choose whether to process surface, subcortex or both')
 @click.option('--skip-tr', default=0, type=click.INT, show_default=True, help='Number of TRs to skip (in case of unwanted peak in data)')
+@click.option('--confounds-filter', type=click.STRING, help='Confounds to select (multiple as list) - partial strings are enough (regex)')
 # 3. Preproc options
 @click.option('--gm-thresh', default=0., show_default=True, help='Threshold for gray-matter mask (if 0, Fmriprep brain masks are used)')  # maybe use a "mask" option
 @click.option('--slice-time-ref', type=click.FLOAT, default=0.5, show_default=True, help='Slice to adjust event onsets to (depends on slice-time correction)')
@@ -75,7 +76,7 @@ from .signal_model import run_signal_processing
 @click.option('--save-mgz', is_flag=True, help='Save surface files as mgz instead of npy files')
 @click.option('--verbose', default='INFO', type=click.Choice(['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']), show_default=True, help='Verbosity level')
 def main(fprep_dir, bids_dir, atlas_file, left_id, right_id, subc_id, out_dir, start_from, ricor_dir, subject, session, pool_sessions, task, space, hemi,
-         iscifti, mode, skip_tr, gm_thresh, slice_time_ref, high_pass_type, high_pass, trial_filter, skip_noiseproc, noise_source, decomp, n_comps,
+         iscifti, mode, skip_tr, confounds_filter, gm_thresh, slice_time_ref, high_pass_type, high_pass, trial_filter, skip_noiseproc, noise_source, decomp, n_comps,
          noiseproc_type, cv_repeats, cv_splits, regularize_n_comps, argmax_percent, skip_signalproc, signalproc_type, contrast,
          single_trial_id, hrf_model, single_trial_noise_model, regularize_hrf_model, single_trial_model, pattern_units, uncorrelation,
          smoothing_fwhm, n_cpus, save_all, save_mgz, verbose):

--- a/pybest/noise_model.py
+++ b/pybest/noise_model.py
@@ -300,7 +300,7 @@ def load_denoising_data(ddict, cfg):
             ddict['trs'] = [load_and_split_cifti(f, cfg['atlas_file'], cfg['left_id'],
                                                  cfg['right_id'], cfg['subc_id'])[1] for f in ddict['funcs']]
         else:
-            ddict['trs'] = [load_gifti(f)[1] for f in ddict['funcs']]
+            ddict['trs'] = [load_gifti(f, cfg)[1] for f in ddict['funcs']]
         ddict['opt_n_comps'] = np.load(op.join(denoising_dir, f'{f_base}_desc-opt_ncomps.npy'))
         if cfg['hrf_model'] == 'kay' and cfg['signalproc_type'] == 'glmdenoise':
             ddict['opt_hrf_idx'] = np.load(op.join(denoising_dir, f'{f_base}_desc-opt_hrf.npy'))

--- a/pybest/noise_model.py
+++ b/pybest/noise_model.py
@@ -13,7 +13,7 @@ from sklearn.model_selection import RepeatedKFold, LeaveOneGroupOut
 
 from .logging import tqdm_ctm, tdesc
 from .utils import get_run_data, get_frame_times, create_design_matrix, hp_filter
-from .utils import save_data, load_gifti, custom_clean, argmax_regularized
+from .utils import save_data, load_gifti, custom_clean, argmax_regularized, load_and_split_cifti
 from .models import cross_val_r2
 
 

--- a/pybest/noise_model.py
+++ b/pybest/noise_model.py
@@ -296,7 +296,11 @@ def load_denoising_data(ddict, cfg):
         ddict['mask'] = nib.load(op.join(preproc_dir, f'{f_base}_desc-preproc_mask.nii.gz'))
 
     if 'fs' in cfg['space']:
-        ddict['trs'] = [load_gifti(f)[1] for f in ddict['funcs']]
+        if cfg['iscift'] == 'y':
+            ddict['trs'] = [load_and_split_cifti(f, cfg['atlas_file'], cfg['left_id'],
+                                                 cfg['right_id'], cfg['subc_id'])[1] for f in ddict['funcs']]
+        else:
+            ddict['trs'] = [load_gifti(f)[1] for f in ddict['funcs']]
         ddict['opt_n_comps'] = np.load(op.join(denoising_dir, f'{f_base}_desc-opt_ncomps.npy'))
         if cfg['hrf_model'] == 'kay' and cfg['signalproc_type'] == 'glmdenoise':
             ddict['opt_hrf_idx'] = np.load(op.join(denoising_dir, f'{f_base}_desc-opt_hrf.npy'))

--- a/pybest/preproc.py
+++ b/pybest/preproc.py
@@ -81,7 +81,7 @@ def _run_func_parallel(ddict, cfg, run, func, logger):
             data, tr = load_and_split_cifti(func, cfg['atlas_file'],cfg, cfg['left_id'], cfg['right_id'], cfg['subc_id'], cfg['mode'])
             tr /= 1000 # defined in msec
         else:
-            data, tr = load_gifti(func, return_tr=True)
+            data, tr = load_gifti(func, cfg, return_tr=True)
             tr /= 1000  # defined in msec
     else:
         # Load/mask data and extract stuff
@@ -383,7 +383,7 @@ def load_preproc_data(ddict, cfg):
             ddict['trs'] = [load_and_split_cifti(f, cfg['atlas_file'], cfg['left_id'],
                                                  cfg['right_id'], cfg['subc_id'])[1] for f in ddict['funcs']]
         else:
-            ddict['trs'] = [load_gifti(f)[1] for f in ddict['funcs']]  # quite inefficient
+            ddict['trs'] = [load_gifti(f, cfg)[1] for f in ddict['funcs']]  # quite inefficient
     else:
         ddict['trs'] = [nib.load(f).header['pixdim'][4] for f in ddict['funcs']]
 

--- a/pybest/preproc.py
+++ b/pybest/preproc.py
@@ -369,7 +369,11 @@ def load_preproc_data(ddict, cfg):
     
     # Load in TRs (inefficient; maybe save/load as yaml?)
     if 'fs' in cfg['space']:
-        ddict['trs'] = [load_gifti(f)[1] for f in ddict['funcs']]  # quite inefficient
+        if cfg['iscift'] == 'y':
+            ddict['trs'] = [load_and_split_cifti(f, cfg['atlas_file'], cfg['left_id'],
+                                                 cfg['right_id'], cfg['subc_id'])[1] for f in ddict['funcs']]
+        else:
+            ddict['trs'] = [load_gifti(f)[1] for f in ddict['funcs']]  # quite inefficient
     else:
         ddict['trs'] = [nib.load(f).header['pixdim'][4] for f in ddict['funcs']]
 

--- a/pybest/preproc.py
+++ b/pybest/preproc.py
@@ -116,7 +116,7 @@ def preprocess_confs_fmriprep(ddict, cfg, logger):
     for i, conf in enumerate(ddict['confs']):
 
         # Load and remove cosine regressors
-        start_tr = [item[1] for item in cfg.get('skip_tr') if conf.str.contains(item[0], case=False, regex=True)][0]
+        start_tr = [item[1] for item in cfg.get('skip_tr') if re.match(item[0], conf, re.IGNORECASE)][0]
         data = pd.read_csv(conf, sep='\t')[start_tr:]
         if cfg['confounds_filter'] is not None:
             confounds = cfg.get('confounds_filter')
@@ -273,10 +273,10 @@ def preprocess_events(ddict, cfg, logger):
     
     data_ = []
     for i, event in enumerate(ddict['events']):
-        first_match = [item for item in cfg.get('skip_tr') if event.str.contains(item[0], case=False, regex=True)][0]
+        first_match = [item for item in cfg.get('skip_tr') if re.match(item[0], event, re.IGNORECASE)][0]
         if first_match:
             skip_tr = first_match[1]
-            match_data = [file for file in ddict['funcs'] if file.str.contains(first_match[0], case=False, regex=True)][0]
+            match_data = [file for file in ddict['funcs'] if re.match(first_match[0], file, re.IGNORECASE)][0]
             if 'fs' in cfg['space']:
                 if cfg['iscift'] == 'y':
                     actual_tr = load_and_split_cifti(match_data, cfg['atlas_file'], cfg['left_id'],

--- a/pybest/preproc.py
+++ b/pybest/preproc.py
@@ -119,9 +119,11 @@ def preprocess_confs_fmriprep(ddict, cfg, logger):
         data = pd.read_csv(conf, sep='\t')[cfg['skip_tr']:]
         if cfg['confounds_filter'] is not None:
             confounds = cfg.get('confounds_filter')
-            col_reg = re.compile('|'.join(confounds))
-            print(col_reg)
-            data = data.filter(regex=col_reg)
+            if type(confounds) == str:
+                data = data.filter(regex=confounds)
+            else:
+                col_reg = re.compile('|'.join(confounds))
+                data = data.filter(regex=col_reg)
 
 
         # Remove cosines and confounds related to the global signal

--- a/pybest/preproc.py
+++ b/pybest/preproc.py
@@ -116,7 +116,7 @@ def preprocess_confs_fmriprep(ddict, cfg, logger):
     for i, conf in enumerate(ddict['confs']):
 
         # Load and remove cosine regressors
-        start_tr = [item[1] for item in cfg.get('skip_tr') if conf.contains(item[0], case=False, regex=True)][0]
+        start_tr = [item[1] for item in cfg.get('skip_tr') if conf.str.contains(item[0], case=False, regex=True)][0]
         data = pd.read_csv(conf, sep='\t')[start_tr:]
         if cfg['confounds_filter'] is not None:
             confounds = cfg.get('confounds_filter')
@@ -273,10 +273,10 @@ def preprocess_events(ddict, cfg, logger):
     
     data_ = []
     for i, event in enumerate(ddict['events']):
-        first_match = [item for item in cfg.get('skip_tr') if event.contains(item[0], case=False, regex=True)][0]
+        first_match = [item for item in cfg.get('skip_tr') if event.str.contains(item[0], case=False, regex=True)][0]
         if first_match:
             skip_tr = first_match[1]
-            match_data = [file for file in ddict['funcs'] if file.contains(first_match[0], case=False, regex=True)][0]
+            match_data = [file for file in ddict['funcs'] if file.str.contains(first_match[0], case=False, regex=True)][0]
             if 'fs' in cfg['space']:
                 if cfg['iscift'] == 'y':
                     actual_tr = load_and_split_cifti(match_data, cfg['atlas_file'], cfg['left_id'],

--- a/pybest/preproc.py
+++ b/pybest/preproc.py
@@ -116,7 +116,8 @@ def preprocess_confs_fmriprep(ddict, cfg, logger):
     for i, conf in enumerate(ddict['confs']):
 
         # Load and remove cosine regressors
-        data = pd.read_csv(conf, sep='\t')[cfg['skip_tr']:]
+        start_tr = [item[1] for item in cfg.get('skip_tr') if conf.str.contains(item[0], case=False, regex=True)][0]
+        data = pd.read_csv(conf, sep='\t')[start_tr:]
         if cfg['confounds_filter'] is not None:
             confounds = cfg.get('confounds_filter')
             if type(confounds) == str:

--- a/pybest/preproc.py
+++ b/pybest/preproc.py
@@ -119,6 +119,7 @@ def preprocess_confs_fmriprep(ddict, cfg, logger):
         start_tr = [item[1] if re.search(item[0], conf, re.IGNORECASE) else 0 for item in cfg.get('skip_tr')][0]
         data = pd.read_csv(conf, sep='\t')[start_tr:]
         if cfg.get('confounds_filter') is not None:
+            print(cfg.get('confounds_filter'))
             confounds = cfg.get('confounds_filter')
             if type(confounds) == str:
                 data = data.filter(regex=confounds)

--- a/pybest/preproc.py
+++ b/pybest/preproc.py
@@ -120,6 +120,7 @@ def preprocess_confs_fmriprep(ddict, cfg, logger):
         if cfg['confounds_filter'] is not None:
             confounds = cfg.get('confounds_filter')
             col_reg = re.compile('|'.join(confounds))
+            print(col_reg)
             data = data.filter(regex=col_reg)
 
 

--- a/pybest/preproc.py
+++ b/pybest/preproc.py
@@ -77,7 +77,7 @@ def _run_func_parallel(ddict, cfg, run, func, logger):
     # Load data
     if 'fs' in cfg['space']:  # assume gifti
         if cfg['iscifti'] == 'y':
-            data, tr = load_and_split_cifti(func, cfg['atlas_file'], cfg['left_id'], cfg['right_id'], cfg['subc_id'], cfg['mode'])
+            data, tr = load_and_split_cifti(func, cfg['atlas_file'], cfg['left_id'], cfg['right_id'], cfg['subc_id'])
             tr /= 1000 # defined in msec
         else:
             data, tr = load_gifti(func, return_tr=True)

--- a/pybest/preproc.py
+++ b/pybest/preproc.py
@@ -3,6 +3,7 @@ import os.path as op
 import numpy as np
 import nibabel as nib
 import pandas as pd
+import re
 from tqdm import tqdm
 from nilearn import image, masking, signal
 from joblib import Parallel, delayed

--- a/pybest/preproc.py
+++ b/pybest/preproc.py
@@ -116,7 +116,7 @@ def preprocess_confs_fmriprep(ddict, cfg, logger):
     for i, conf in enumerate(ddict['confs']):
 
         # Load and remove cosine regressors
-        start_tr = [item[1] for item in cfg.get('skip_tr') if re.match(item[0], conf, re.IGNORECASE)][0]
+        start_tr = [item[1] if re.search(item[0], conf, re.IGNORECASE) else 0 for item in cfg.get('skip_tr')][0]
         data = pd.read_csv(conf, sep='\t')[start_tr:]
         if cfg['confounds_filter'] is not None:
             confounds = cfg.get('confounds_filter')
@@ -273,10 +273,10 @@ def preprocess_events(ddict, cfg, logger):
     
     data_ = []
     for i, event in enumerate(ddict['events']):
-        first_match = [item for item in cfg.get('skip_tr') if re.match(item[0], event, re.IGNORECASE)][0]
+        first_match = [item if re.search(item[0], event, re.IGNORECASE) else 0 for item in cfg.get('skip_tr')][0]
         if first_match:
             skip_tr = first_match[1]
-            match_data = [file for file in ddict['funcs'] if re.match(first_match[0], file, re.IGNORECASE)][0]
+            match_data = [file if re.search(first_match[0], file, re.IGNORECASE) else 0 for file in ddict['funcs']][0]
             if 'fs' in cfg['space']:
                 if cfg['iscift'] == 'y':
                     actual_tr = load_and_split_cifti(match_data, cfg['atlas_file'], cfg['left_id'],

--- a/pybest/preproc.py
+++ b/pybest/preproc.py
@@ -77,7 +77,7 @@ def _run_func_parallel(ddict, cfg, run, func, logger):
     # Load data
     if 'fs' in cfg['space']:  # assume gifti
         if cfg['iscifti'] == 'y':
-            data, tr = load_and_split_cifti(func, cfg['atlas_file'], cfg['left_id'], cfg['right_id'], cfg['subc_id'])
+            data, tr = load_and_split_cifti(func, cfg['atlas_file'],cfg, cfg['left_id'], cfg['right_id'], cfg['subc_id'])
             tr /= 1000 # defined in msec
         else:
             data, tr = load_gifti(func, return_tr=True)

--- a/pybest/preproc.py
+++ b/pybest/preproc.py
@@ -12,7 +12,7 @@ from sklearn.linear_model import LinearRegression
 
 from .logging import tqdm_ctm, tdesc
 from .models import cross_val_r2
-from .utils import load_gifti, get_frame_times, create_design_matrix, hp_filter, save_data
+from .utils import load_gifti, get_frame_times, create_design_matrix, hp_filter, save_data, load_and_split_cifti
 
 
 def preprocess_funcs(ddict, cfg, logger):

--- a/pybest/preproc.py
+++ b/pybest/preproc.py
@@ -115,7 +115,7 @@ def preprocess_confs_fmriprep(ddict, cfg, logger):
     for i, conf in enumerate(ddict['confs']):
 
         # Load and remove cosine regressors
-        data = pd.read_csv(conf, sep='\t')
+        data = pd.read_csv(conf, sep='\t')[cfg['skip_tr']:]
         # Remove cosines and confounds related to the global signal
         # Anecdotal evidence that leaving out the global signal gives better results ...
         to_remove = [col for col in data.columns if 'cosine' in col or 'global' in col]

--- a/pybest/preproc.py
+++ b/pybest/preproc.py
@@ -116,6 +116,11 @@ def preprocess_confs_fmriprep(ddict, cfg, logger):
 
         # Load and remove cosine regressors
         data = pd.read_csv(conf, sep='\t')[cfg['skip_tr']:]
+        if cfg['confounds_filter'] is not None:
+            col_reg = re.compile('|'.join(cfg['confounds_filter']))
+            data = data.filter(regex=col_reg)
+
+
         # Remove cosines and confounds related to the global signal
         # Anecdotal evidence that leaving out the global signal gives better results ...
         to_remove = [col for col in data.columns if 'cosine' in col or 'global' in col]

--- a/pybest/preproc.py
+++ b/pybest/preproc.py
@@ -77,7 +77,7 @@ def _run_func_parallel(ddict, cfg, run, func, logger):
     # Load data
     if 'fs' in cfg['space']:  # assume gifti
         if cfg['iscifti'] == 'y':
-            data, tr = load_and_split_cifti(func, cfg['atlas_file'],cfg, cfg['left_id'], cfg['right_id'], cfg['subc_id'])
+            data, tr = load_and_split_cifti(func, cfg['atlas_file'],cfg, cfg['left_id'], cfg['right_id'], cfg['subc_id'], cfg['mode'])
             tr /= 1000 # defined in msec
         else:
             data, tr = load_gifti(func, return_tr=True)

--- a/pybest/preproc.py
+++ b/pybest/preproc.py
@@ -118,8 +118,7 @@ def preprocess_confs_fmriprep(ddict, cfg, logger):
         # Load and remove cosine regressors
         start_tr = [item[1] if re.search(item[0], conf, re.IGNORECASE) else 0 for item in cfg.get('skip_tr')][0]
         data = pd.read_csv(conf, sep='\t')[start_tr:]
-        if cfg.get('confounds_filter') is not None:
-            print(cfg.get('confounds_filter'))
+        if cfg.get('confounds_filter')[0] is not None:
             confounds = cfg.get('confounds_filter')
             if type(confounds) == str:
                 data = data.filter(regex=confounds)

--- a/pybest/preproc.py
+++ b/pybest/preproc.py
@@ -118,7 +118,8 @@ def preprocess_confs_fmriprep(ddict, cfg, logger):
         # Load and remove cosine regressors
         data = pd.read_csv(conf, sep='\t')[cfg['skip_tr']:]
         if cfg['confounds_filter'] is not None:
-            col_reg = re.compile('|'.join(cfg['confounds_filter']))
+            confounds = cfg.get('confounds_filter')
+            col_reg = re.compile('|'.join(confounds))
             data = data.filter(regex=col_reg)
 
 

--- a/pybest/preproc.py
+++ b/pybest/preproc.py
@@ -116,7 +116,7 @@ def preprocess_confs_fmriprep(ddict, cfg, logger):
     for i, conf in enumerate(ddict['confs']):
 
         # Load and remove cosine regressors
-        start_tr = [item[1] for item in cfg.get('skip_tr') if conf.str.contains(item[0], case=False, regex=True)][0]
+        start_tr = [item[1] for item in cfg.get('skip_tr') if conf.contains(item[0], case=False, regex=True)][0]
         data = pd.read_csv(conf, sep='\t')[start_tr:]
         if cfg['confounds_filter'] is not None:
             confounds = cfg.get('confounds_filter')
@@ -273,10 +273,10 @@ def preprocess_events(ddict, cfg, logger):
     
     data_ = []
     for i, event in enumerate(ddict['events']):
-        first_match = [item for item in cfg.get('skip_tr') if event.str.contains(item[0], case=False, regex=True)][0]
+        first_match = [item for item in cfg.get('skip_tr') if event.contains(item[0], case=False, regex=True)][0]
         if first_match:
             skip_tr = first_match[1]
-            match_data = [file for file in ddict['funcs'] if file.str.contains(first_match[0], case=False, regex=True)][0]
+            match_data = [file for file in ddict['funcs'] if file.contains(first_match[0], case=False, regex=True)][0]
             if 'fs' in cfg['space']:
                 if cfg['iscift'] == 'y':
                     actual_tr = load_and_split_cifti(match_data, cfg['atlas_file'], cfg['left_id'],

--- a/pybest/preproc.py
+++ b/pybest/preproc.py
@@ -118,7 +118,7 @@ def preprocess_confs_fmriprep(ddict, cfg, logger):
         # Load and remove cosine regressors
         start_tr = [item[1] if re.search(item[0], conf, re.IGNORECASE) else 0 for item in cfg.get('skip_tr')][0]
         data = pd.read_csv(conf, sep='\t')[start_tr:]
-        if cfg['confounds_filter'] is not None:
+        if cfg.get('confounds_filter') is not None:
             confounds = cfg.get('confounds_filter')
             if type(confounds) == str:
                 data = data.filter(regex=confounds)

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -143,7 +143,6 @@ def load_and_split_cifti(cifti, indices_file, cfg, left_id=None, right_id=None, 
     elif mode=='all' and return_tr==True:
         data = np.vstack([l, r])[:,2:]
         actual, pos, zdat = get_valid_voxels(s[:,:,:,2:])
-        print(zdat.shape)
         data = np.vstack([data, actual])
         cfg['pos'] = pos
         cfg['subc_original'] = s[:, :, :, 2:]

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -110,10 +110,10 @@ def load_and_split_cifti(cifti, indices_file, left_id=None, right_id=None, subc_
 
     if mode == 'surface' and return_tr==True:
         data = np.vstack([l.T, r.T])
-        return data.T, tr
+        return data, tr
     elif mode == 'surface' and return_tr==False:
         data = np.vstack([l.T, r.T])
-        return data.T
+        return data
 
     if mode == 'all' or mode == 'subcortex':
         # Get indexes for valid elements.
@@ -136,12 +136,12 @@ def load_and_split_cifti(cifti, indices_file, left_id=None, right_id=None, subc_
 
     elif mode=='all' and return_tr==True:
         data = np.vstack([l.T, r.T])
-        return data.T, s, tr
+        return data, s, tr
 
 
     else:
         data = np.vstack([l.T, r.T])
-        return data.T, s
+        return data, s
 
 
 def argmax_regularized(data, axis=0, percent=5):

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -26,7 +26,7 @@ def load_gifti(f, cfg, return_tr=True):
     """ Load gifti array. """
     f_gif = nib.load(f)
     data = np.vstack([arr.data for arr in f_gif.darrays])
-    start_tr = [item[1] for item in cfg.get('skip_tr') if f.contains(item[0], case=False, regex=True)][0]
+    start_tr = [item[1] for item in cfg.get('skip_tr') if f.str.contains(item[0], case=False, regex=True)][0]
     tr = float(f_gif.darrays[0].get_metadata()['TimeStep'])
     if return_tr:
         return data[start_tr:,:], tr
@@ -97,7 +97,7 @@ def load_and_split_cifti(cifti, indices_file, cfg, left_id=None, right_id=None, 
     datvol = nib.load(cifti)
     tr = datvol.header.get_axis(0)[1]
     dat = np.asanyarray(datvol.dataobj)
-    start_tr = [item[1] for item in cfg.get('skip_tr') if cifti.contains(item[0], case=False, regex=True)][0]
+    start_tr = [item[1] for item in cfg.get('skip_tr') if cifti.str.contains(item[0], case=False, regex=True)][0]
     if mode == 'all' or mode == 'surface':
         # Populate left and right hemisphere.
         l, r, = dat[:, lidxs], dat[:, ridxs]

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -26,7 +26,7 @@ def load_gifti(f, cfg, return_tr=True):
     """ Load gifti array. """
     f_gif = nib.load(f)
     data = np.vstack([arr.data for arr in f_gif.darrays])
-    start_tr = [item[1] for item in cfg.get('skip_tr') if f.str.contains(item[0])][0]
+    start_tr = [item[1] for item in cfg.get('skip_tr') if f.str.contains(item[0], case=False, regex=True)][0]
     tr = float(f_gif.darrays[0].get_metadata()['TimeStep'])
     if return_tr:
         return data[start_tr:,:], tr
@@ -97,7 +97,7 @@ def load_and_split_cifti(cifti, indices_file, cfg, left_id=None, right_id=None, 
     datvol = nib.load(cifti)
     tr = datvol.header.get_axis(0)[1]
     dat = np.asanyarray(datvol.dataobj)
-    start_tr = [item[1] for item in cfg.get('skip_tr') if cifti.str.contains(item[0])][0]
+    start_tr = [item[1] for item in cfg.get('skip_tr') if cifti.str.contains(item[0], case=False, regex=True)][0]
     if mode == 'all' or mode == 'surface':
         # Populate left and right hemisphere.
         l, r, = dat[:, lidxs], dat[:, ridxs]

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -145,7 +145,7 @@ def load_and_split_cifti(cifti, indices_file, left_id=None, right_id=None, subc_
     else:
         data = np.vstack([l, r])
         actual, pos, zdat = get_valid_voxels(s[:, :, :, 2:])
-        return data.T[2:,:], actual, pos, zdat
+        return data.T[2:,:], actual.T, pos, zdat
 
 
 def get_valid_voxels(data):

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -143,6 +143,7 @@ def load_and_split_cifti(cifti, indices_file, cfg, left_id=None, right_id=None, 
     elif mode=='all' and return_tr==True:
         data = np.vstack([l, r])[:,2:]
         actual, pos, zdat = get_valid_voxels(s[:,:,:,2:])
+        print(zdat.shape)
         data = np.vstack([data, actual])
         cfg['pos'] = pos
         cfg['zdat'] = zdat
@@ -277,6 +278,7 @@ def save_data(data, cfg, ddict, par_dir, desc, dtype, run=None, ext=None,
                 subc_data = data[:,surf_len:]
                 surface_data = data[:, :surf_len].T
                 zdat = cfg['zdat']
+                print(zdat.shape)
                 pos = cfg['pos']
                 zdat[pos] = subc_data.T
                 np.save(f_out + '_subc.npy', zdat)

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -144,7 +144,8 @@ def load_and_split_cifti(cifti, indices_file, left_id=None, right_id=None, subc_
 
     else:
         data = np.vstack([l, r])
-        return data.T[2:,:], s
+        actual, pos, zdat = get_valid_voxels(s[:, :, :, 2:])
+        return data.T[2:,:], actual, pos, zdat
 
 
 def get_valid_voxels(data):

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -141,19 +141,23 @@ def load_and_split_cifti(cifti, indices_file, cfg, left_id=None, right_id=None, 
         return actual.T
 
     elif mode=='all' and return_tr==True:
-        data = np.vstack([l, r])
+        data = np.vstack([l, r])[:,2:]
         actual, pos, zdat = get_valid_voxels(s[:,:,:,2:])
+        data = np.vstack([data, actual])
         cfg['pos'] = pos
         cfg['zdat'] = zdat
-        return data.T[2:,:], actual.T, tr
+        cfg['subc_len'] = actual.shape[0]
+        return data.T, tr
 
 
     else:
-        data = np.vstack([l, r])
+        data = np.vstack([l, r])[:,2:]
         actual, pos, zdat = get_valid_voxels(s[:, :, :, 2:])
+        data = np.vstack([data, actual])
         cfg['pos'] = pos
         cfg['zdat'] = zdat
-        return data.T[2:,:], actual.T
+        cfg['subc_len'] = actual.shape[0]
+        return data.T
 
 
 def get_valid_voxels(data):

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -98,10 +98,7 @@ def load_and_split_cifti(cifti, indices_file, cfg, left_id=None, right_id=None, 
     datvol = nib.load(cifti)
     tr = datvol.header.get_axis(0)[1]
     dat = np.asanyarray(datvol.dataobj)
-    start_tr = [item[1] if re.match(item[0], cifti, re.IGNORECASE) else 0 for item in cfg.get('skip_tr')][0]
-    for item in cfg.get('skip_tr'):
-        print(item[0])
-    #print(cfg.get('skip_tr'))
+    start_tr = [item[1] if re.match(str(item[0]), cifti, re.IGNORECASE) else 0 for item in cfg.get('skip_tr')][0]
     print(start_tr)
     print(cifti)
     if mode == 'all' or mode == 'surface':

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -33,7 +33,7 @@ def load_gifti(f, return_tr=True):
         return data
 
 
-def load_and_split_cifti(cifti, indices_file, left_id=None, right_id=None, subc_id=None, mode='surface', return_tr=True):
+def load_and_split_cifti(cifti, indices_file, cfg, left_id=None, right_id=None, subc_id=None, mode='surface', return_tr=True):
     """
     Takes a cifti file and splits it into 3 numpy arrays (left hemisphere,
     right hemispehre and subcortex).
@@ -130,22 +130,30 @@ def load_and_split_cifti(cifti, indices_file, left_id=None, right_id=None, subc_
 
     if mode == 'subcortex' and return_tr==True:
         actual, pos, zdat = get_valid_voxels(s[:, :, :, 2:])
-        return actual.T, pos, zdat, tr
+        cfg['pos'] = pos
+        cfg['zdat'] = zdat
+        return actual.T, tr
 
     elif mode == 'subcortex' and return_tr==False:
         actual, pos, zdat = get_valid_voxels(s[:, :, :, 2:])
-        return actual.T, pos, zdat
+        cfg['pos'] = pos
+        cfg['zdat'] = zdat
+        return actual.T
 
     elif mode=='all' and return_tr==True:
         data = np.vstack([l, r])
         actual, pos, zdat = get_valid_voxels(s[:,:,:,2:])
-        return data.T[2:,:], actual.T, pos, zdat, tr
+        cfg['pos'] = pos
+        cfg['zdat'] = zdat
+        return data.T[2:,:], actual.T, tr
 
 
     else:
         data = np.vstack([l, r])
         actual, pos, zdat = get_valid_voxels(s[:, :, :, 2:])
-        return data.T[2:,:], actual.T, pos, zdat
+        cfg['pos'] = pos
+        cfg['zdat'] = zdat
+        return data.T[2:,:], actual.T
 
 
 def get_valid_voxels(data):

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -26,7 +26,7 @@ def load_gifti(f, cfg, return_tr=True):
     """ Load gifti array. """
     f_gif = nib.load(f)
     data = np.vstack([arr.data for arr in f_gif.darrays])
-    start_tr = cfg['skip_tr']
+    start_tr = [item[1] for item in cfg.get('skip_tr') if cifti.str.contains(item[0])][0]
     tr = float(f_gif.darrays[0].get_metadata()['TimeStep'])
     if return_tr:
         return data[start_tr:,:], tr
@@ -97,7 +97,7 @@ def load_and_split_cifti(cifti, indices_file, cfg, left_id=None, right_id=None, 
     datvol = nib.load(cifti)
     tr = datvol.header.get_axis(0)[1]
     dat = np.asanyarray(datvol.dataobj)
-    start_tr = cfg['skip_tr']
+    start_tr = [item[1] for item in cfg.get('skip_tr') if cifti.str.contains(item[0])][0]
     if mode == 'all' or mode == 'surface':
         # Populate left and right hemisphere.
         l, r, = dat[:, lidxs], dat[:, ridxs]

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -26,7 +26,7 @@ def load_gifti(f, cfg, return_tr=True):
     """ Load gifti array. """
     f_gif = nib.load(f)
     data = np.vstack([arr.data for arr in f_gif.darrays])
-    start_tr = [item[1] for item in cfg.get('skip_tr') if cifti.str.contains(item[0])][0]
+    start_tr = [item[1] for item in cfg.get('skip_tr') if f.str.contains(item[0])][0]
     tr = float(f_gif.darrays[0].get_metadata()['TimeStep'])
     if return_tr:
         return data[start_tr:,:], tr

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -99,6 +99,8 @@ def load_and_split_cifti(cifti, indices_file, cfg, left_id=None, right_id=None, 
     tr = datvol.header.get_axis(0)[1]
     dat = np.asanyarray(datvol.dataobj)
     start_tr = [item[1] if re.match(item[0], cifti, re.IGNORECASE) else 0 for item in cfg.get('skip_tr')][0]
+    print(start_tr)
+    print(cifti)
     if mode == 'all' or mode == 'surface':
         # Populate left and right hemisphere.
         l, r, = dat[:, lidxs], dat[:, ridxs]

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -268,20 +268,13 @@ def save_data(data, cfg, ddict, par_dir, desc, dtype, run=None, ext=None,
             nib.MGHImage(data, np.eye(4)).to_filename(f_out + '.mgz')
         else:
             if cfg['iscifti'] == 'y' and cfg['mode'] == 'subcortex':
-                zdat = cfg['zdat']
-                pos = cfg['pos']
-                zdat[pos] = data.T
-                np.save(f_out + '_subc.npy', zdat)
+                np.save(f_out + '_subc.npy', data.T)
             elif cfg['iscifti'] == 'y' and cfg['mode'] == 'all':
                 # split in surface and subcortex, save both
                 surf_len = data.shape[1] - cfg['subc_len']
-                subc_data = data[:,surf_len:]
+                subc_data = data[:,surf_len:].T
                 surface_data = data[:, :surf_len].T
-                zdat = cfg['zdat']
-                print(zdat.shape)
-                pos = cfg['pos']
-                zdat[pos] = subc_data.T
-                np.save(f_out + '_subc.npy', zdat)
+                np.save(f_out + '_subc.npy', subc_data)
                 np.save(f_out + '.npy', surface_data)
             elif cfg['iscifti'] == 'y' and cfg['mode'] == 'surface':
                 np.save(f_out + '.npy', data.T)

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -110,10 +110,10 @@ def load_and_split_cifti(cifti, indices_file, left_id=None, right_id=None, subc_
 
     if mode == 'surface' and return_tr==True:
         data = np.vstack([l, r])
-        return data.T, tr
+        return data.T[2:,:], tr
     elif mode == 'surface' and return_tr==False:
         data = np.vstack([l, r])
-        return data.T
+        return data.T[2:,:]
 
     if mode == 'all' or mode == 'subcortex':
         # Get indexes for valid elements.
@@ -136,12 +136,12 @@ def load_and_split_cifti(cifti, indices_file, left_id=None, right_id=None, subc_
 
     elif mode=='all' and return_tr==True:
         data = np.vstack([l, r])
-        return data.T, s, tr
+        return data.T[2:,:], s, tr
 
 
     else:
         data = np.vstack([l, r])
-        return data.T, s
+        return data.T[2:,:], s
 
 
 def argmax_regularized(data, axis=0, percent=5):

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -99,7 +99,9 @@ def load_and_split_cifti(cifti, indices_file, cfg, left_id=None, right_id=None, 
     tr = datvol.header.get_axis(0)[1]
     dat = np.asanyarray(datvol.dataobj)
     start_tr = [item[1] if re.match(item[0], cifti, re.IGNORECASE) else 0 for item in cfg.get('skip_tr')][0]
-    print(cfg.get('skip_tr'))
+    for item in cfg.get('skip_tr'):
+        print(item[0])
+    #print(cfg.get('skip_tr'))
     print(start_tr)
     print(cifti)
     if mode == 'all' or mode == 'surface':

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -27,7 +27,7 @@ def load_gifti(f, cfg, return_tr=True):
     """ Load gifti array. """
     f_gif = nib.load(f)
     data = np.vstack([arr.data for arr in f_gif.darrays])
-    start_tr = [item[1] if re.match(item[0], f, re.IGNORECASE) else 0 for item in cfg.get('skip_tr')][0]
+    start_tr = [item[1] if re.search(item[0], f, re.IGNORECASE) else 0 for item in cfg.get('skip_tr')][0]
     tr = float(f_gif.darrays[0].get_metadata()['TimeStep'])
     if return_tr:
         return data[start_tr:,:], tr
@@ -98,12 +98,7 @@ def load_and_split_cifti(cifti, indices_file, cfg, left_id=None, right_id=None, 
     datvol = nib.load(cifti)
     tr = datvol.header.get_axis(0)[1]
     dat = np.asanyarray(datvol.dataobj)
-    start_tr = [item[1] if re.match(str(item[0]), cifti, re.IGNORECASE) else 0 for item in cfg.get('skip_tr')][0]
-    for item in cfg.get('skip_tr'):
-        m = re.search(item[0], cifti, re.IGNORECASE)
-        print(m)
-    print(start_tr)
-    print(cifti)
+    start_tr = [item[1] if re.search(str(item[0]), cifti, re.IGNORECASE) else 0 for item in cfg.get('skip_tr')][0]
     if mode == 'all' or mode == 'surface':
         # Populate left and right hemisphere.
         l, r, = dat[:, lidxs], dat[:, ridxs]

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -371,7 +371,7 @@ def get_run_data(ddict, run, func_type='preproc'):
 
     t_idx = ddict['run_idx'] == run  # timepoint index
     func = ddict[f'{func_type}_func'][t_idx, :].copy()
-    conf = ddict['preproc_conf'].copy().loc[t_idx, :].to_numpy()
+    conf = ddict['preproc_conf'][2:,:].copy().loc[t_idx, :].to_numpy()
 
     if ddict['preproc_events'] is not None:
         events = ddict['preproc_events'].copy().query("run == (@run + 1)")

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -237,7 +237,7 @@ def save_data(data, cfg, ddict, par_dir, desc, dtype, run=None, ext=None,
 
     sub, ses, task, space, hemi = cfg['c_sub'], cfg['c_ses'], cfg['c_task'], cfg['space'], cfg['hemi']
     if cfg['iscifti'] == 'y':
-        space_idf = f'fsLR' if 'fs' in space else space
+        space_idf = space
     else:
         space_idf = f'{space}_hemi-{hemi}' if 'fs' in space else space
 

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -99,6 +99,7 @@ def load_and_split_cifti(cifti, indices_file, cfg, left_id=None, right_id=None, 
     tr = datvol.header.get_axis(0)[1]
     dat = np.asanyarray(datvol.dataobj)
     start_tr = [item[1] if re.match(item[0], cifti, re.IGNORECASE) else 0 for item in cfg.get('skip_tr')][0]
+    print(cfg.get('skip_tr'))
     print(start_tr)
     print(cifti)
     if mode == 'all' or mode == 'surface':

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -371,7 +371,7 @@ def get_run_data(ddict, run, func_type='preproc'):
 
     t_idx = ddict['run_idx'] == run  # timepoint index
     func = ddict[f'{func_type}_func'][t_idx, :].copy()
-    conf = ddict['preproc_conf'][2:,:].copy().loc[t_idx, :].to_numpy()
+    conf = ddict['preproc_conf'].copy().loc[t_idx, :].to_numpy()
 
     if ddict['preproc_events'] is not None:
         events = ddict['preproc_events'].copy().query("run == (@run + 1)")

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -26,7 +26,7 @@ def load_gifti(f, cfg, return_tr=True):
     """ Load gifti array. """
     f_gif = nib.load(f)
     data = np.vstack([arr.data for arr in f_gif.darrays])
-    start_tr = [item[1] for item in cfg.get('skip_tr') if f.str.contains(item[0], case=False, regex=True)][0]
+    start_tr = [item[1] for item in cfg.get('skip_tr') if f.contains(item[0], case=False, regex=True)][0]
     tr = float(f_gif.darrays[0].get_metadata()['TimeStep'])
     if return_tr:
         return data[start_tr:,:], tr
@@ -97,7 +97,7 @@ def load_and_split_cifti(cifti, indices_file, cfg, left_id=None, right_id=None, 
     datvol = nib.load(cifti)
     tr = datvol.header.get_axis(0)[1]
     dat = np.asanyarray(datvol.dataobj)
-    start_tr = [item[1] for item in cfg.get('skip_tr') if cifti.str.contains(item[0], case=False, regex=True)][0]
+    start_tr = [item[1] for item in cfg.get('skip_tr') if cifti.contains(item[0], case=False, regex=True)][0]
     if mode == 'all' or mode == 'surface':
         # Populate left and right hemisphere.
         l, r, = dat[:, lidxs], dat[:, ridxs]

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -370,7 +370,11 @@ def get_run_data(ddict, run, func_type='preproc'):
     """ Get the data for a specific run. """
 
     t_idx = ddict['run_idx'] == run  # timepoint index
+    print(t_idx)
+    print(ddict[f'{func_type}_func'].shape)
     func = ddict[f'{func_type}_func'][t_idx, :].copy()
+    print(func.shape)
+    print(ddict['preproc_conf'].shape)
     conf = ddict['preproc_conf'].copy().loc[t_idx, :].to_numpy()
 
     if ddict['preproc_events'] is not None:

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -99,6 +99,9 @@ def load_and_split_cifti(cifti, indices_file, cfg, left_id=None, right_id=None, 
     tr = datvol.header.get_axis(0)[1]
     dat = np.asanyarray(datvol.dataobj)
     start_tr = [item[1] if re.match(str(item[0]), cifti, re.IGNORECASE) else 0 for item in cfg.get('skip_tr')][0]
+    for item in cfg.get('skip_tr'):
+        m = re.match(str(item[0]), cifti, re.IGNORECASE)
+        print(m)
     print(start_tr)
     print(cifti)
     if mode == 'all' or mode == 'surface':

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -22,15 +22,16 @@ from nilearn.glm.first_level.design_matrix import _cosine_drift as dct_set
 from .constants import HRFS_HR
 
 
-def load_gifti(f, return_tr=True):
+def load_gifti(f, cfg, return_tr=True):
     """ Load gifti array. """
     f_gif = nib.load(f)
     data = np.vstack([arr.data for arr in f_gif.darrays])
+    start_tr = cfg['skip_tr']
     tr = float(f_gif.darrays[0].get_metadata()['TimeStep'])
     if return_tr:
-        return data, tr
+        return data[start_tr:,:], tr
     else:
-        return data
+        return data[start_tr:,:]
 
 
 def load_and_split_cifti(cifti, indices_file, cfg, left_id=None, right_id=None, subc_id=None, mode='surface', return_tr=True):

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -140,7 +140,7 @@ def load_and_split_cifti(cifti, indices_file, left_id=None, right_id=None, subc_
 
 
     else:
-        data = np.vstack([l.T, r.T])
+        data = np.vstack([l, r])
         return data.T, s
 
 

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -274,7 +274,7 @@ def save_data(data, cfg, ddict, par_dir, desc, dtype, run=None, ext=None,
             elif cfg['iscifti'] == 'y' and cfg['mode'] == 'all':
                 # split in surface and subcortex, save both
                 surf_len = data.shape[1] - cfg['subc_len']
-                subc_data = data[:,surf_len-1:]
+                subc_data = data[:,surf_len:]
                 surface_data = data[:, :surf_len].T
                 zdat = cfg['zdat']
                 pos = cfg['pos']

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -109,10 +109,10 @@ def load_and_split_cifti(cifti, indices_file, left_id=None, right_id=None, subc_
         l, r = l.T, r.T
 
     if mode == 'surface' and return_tr==True:
-        data = np.vstack([l.T, r.T])
+        data = np.vstack([l, r])
         return data.T, tr
     elif mode == 'surface' and return_tr==False:
-        data = np.vstack([l.T, r.T])
+        data = np.vstack([l, r])
         return data.T
 
     if mode == 'all' or mode == 'subcortex':
@@ -135,7 +135,7 @@ def load_and_split_cifti(cifti, indices_file, left_id=None, right_id=None, subc_
         return s
 
     elif mode=='all' and return_tr==True:
-        data = np.vstack([l.T, r.T])
+        data = np.vstack([l, r])
         return data.T, s, tr
 
 

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -6,6 +6,7 @@ import numpy as np
 import nibabel as nib
 import pandas as pd
 import h5py
+import re
 from tqdm import tqdm
 from glob import glob
 from scipy.interpolate import interp1d
@@ -26,7 +27,7 @@ def load_gifti(f, cfg, return_tr=True):
     """ Load gifti array. """
     f_gif = nib.load(f)
     data = np.vstack([arr.data for arr in f_gif.darrays])
-    start_tr = [item[1] for item in cfg.get('skip_tr') if f.str.contains(item[0], case=False, regex=True)][0]
+    start_tr = [item[1] for item in cfg.get('skip_tr') if re.match(item[0], f, re.IGNORECASE)][0]
     tr = float(f_gif.darrays[0].get_metadata()['TimeStep'])
     if return_tr:
         return data[start_tr:,:], tr
@@ -97,7 +98,7 @@ def load_and_split_cifti(cifti, indices_file, cfg, left_id=None, right_id=None, 
     datvol = nib.load(cifti)
     tr = datvol.header.get_axis(0)[1]
     dat = np.asanyarray(datvol.dataobj)
-    start_tr = [item[1] for item in cfg.get('skip_tr') if cifti.str.contains(item[0], case=False, regex=True)][0]
+    start_tr = [item[1] for item in cfg.get('skip_tr') if re.match(item[0], cifti, re.IGNORECASE)][0]
     if mode == 'all' or mode == 'surface':
         # Populate left and right hemisphere.
         l, r, = dat[:, lidxs], dat[:, ridxs]

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -370,11 +370,7 @@ def get_run_data(ddict, run, func_type='preproc'):
     """ Get the data for a specific run. """
 
     t_idx = ddict['run_idx'] == run  # timepoint index
-    print(t_idx)
-    print(ddict[f'{func_type}_func'].shape)
     func = ddict[f'{func_type}_func'][t_idx, :].copy()
-    print(func.shape)
-    print(ddict['preproc_conf'].shape)
     conf = ddict['preproc_conf'].copy().loc[t_idx, :].to_numpy()
 
     if ddict['preproc_events'] is not None:

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -110,10 +110,10 @@ def load_and_split_cifti(cifti, indices_file, left_id=None, right_id=None, subc_
 
     if mode == 'surface' and return_tr==True:
         data = np.vstack([l.T, r.T])
-        return data, tr
+        return data.T, tr
     elif mode == 'surface' and return_tr==False:
         data = np.vstack([l.T, r.T])
-        return data
+        return data.T
 
     if mode == 'all' or mode == 'subcortex':
         # Get indexes for valid elements.
@@ -136,12 +136,12 @@ def load_and_split_cifti(cifti, indices_file, left_id=None, right_id=None, subc_
 
     elif mode=='all' and return_tr==True:
         data = np.vstack([l.T, r.T])
-        return data, s, tr
+        return data.T, s, tr
 
 
     else:
         data = np.vstack([l.T, r.T])
-        return data, s
+        return data.T, s
 
 
 def argmax_regularized(data, axis=0, percent=5):

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -100,7 +100,7 @@ def load_and_split_cifti(cifti, indices_file, cfg, left_id=None, right_id=None, 
     dat = np.asanyarray(datvol.dataobj)
     start_tr = [item[1] if re.match(str(item[0]), cifti, re.IGNORECASE) else 0 for item in cfg.get('skip_tr')][0]
     for item in cfg.get('skip_tr'):
-        m = re.match(str(item[0]), cifti, re.IGNORECASE)
+        m = re.search(item[0], cifti, re.IGNORECASE)
         print(m)
     print(start_tr)
     print(cifti)

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -33,7 +33,7 @@ def load_gifti(f, return_tr=True):
         return data
 
 
-def load_and_split_cifti(cifti, indices_file, left_id=None, right_id=None, subc_id=None, mode='all', return_tr=True):
+def load_and_split_cifti(cifti, indices_file, left_id=None, right_id=None, subc_id=None, mode='surface', return_tr=True):
     """
     Takes a cifti file and splits it into 3 numpy arrays (left hemisphere,
     right hemispehre and subcortex).

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -96,7 +96,7 @@ def load_and_split_cifti(cifti, indices_file, cfg, left_id=None, right_id=None, 
     datvol = nib.load(cifti)
     tr = datvol.header.get_axis(0)[1]
     dat = np.asanyarray(datvol.dataobj)
-
+    start_tr = cfg['skip_tr']
     if mode == 'all' or mode == 'surface':
         # Populate left and right hemisphere.
         l, r, = dat[:, lidxs], dat[:, ridxs]
@@ -110,10 +110,10 @@ def load_and_split_cifti(cifti, indices_file, cfg, left_id=None, right_id=None, 
 
     if mode == 'surface' and return_tr==True:
         data = np.vstack([l, r])
-        return data.T[2:,:], tr
+        return data.T[start_tr:,:], tr
     elif mode == 'surface' and return_tr==False:
         data = np.vstack([l, r])
-        return data.T[2:,:]
+        return data.T[start_tr:,:]
 
     if mode == 'all' or mode == 'subcortex':
         # Get indexes for valid elements.
@@ -129,33 +129,33 @@ def load_and_split_cifti(cifti, indices_file, cfg, left_id=None, right_id=None, 
         s = np.moveaxis(s, 0, -1)
 
     if mode == 'subcortex' and return_tr==True:
-        actual, pos, zdat = get_valid_voxels(s[:, :, :, 2:])
+        actual, pos, zdat = get_valid_voxels(s[:, :, :, start_tr:])
         cfg['pos'] = pos
-        cfg['subc_original'] = s[:, :, :, 2:]
+        cfg['subc_original'] = s[:, :, :, start_tr:]
         return actual.T, tr
 
     elif mode == 'subcortex' and return_tr==False:
-        actual, pos, zdat = get_valid_voxels(s[:, :, :, 2:])
+        actual, pos, zdat = get_valid_voxels(s[:, :, :, start_tr:])
         cfg['pos'] = pos
-        cfg['subc_original'] = s[:, :, :, 2:]
+        cfg['subc_original'] = s[:, :, :, start_tr:]
         return actual.T
 
     elif mode=='all' and return_tr==True:
-        data = np.vstack([l, r])[:,2:]
-        actual, pos, zdat = get_valid_voxels(s[:,:,:,2:])
+        data = np.vstack([l, r])[:,start_tr:]
+        actual, pos, zdat = get_valid_voxels(s[:,:,:,start_tr:])
         data = np.vstack([data, actual])
         cfg['pos'] = pos
-        cfg['subc_original'] = s[:, :, :, 2:]
+        cfg['subc_original'] = s[:, :, :, start_tr:]
         cfg['subc_len'] = actual.shape[0]
         return data.T, tr
 
 
     else:
-        data = np.vstack([l, r])[:,2:]
-        actual, pos, zdat = get_valid_voxels(s[:, :, :, 2:])
+        data = np.vstack([l, r])[:,start_tr:]
+        actual, pos, zdat = get_valid_voxels(s[:, :, :, start_tr:])
         data = np.vstack([data, actual])
         cfg['pos'] = pos
-        cfg['subc_original'] = s[:, :, :, 2:]
+        cfg['subc_original'] = s[:, :, :, start_tr:]
         cfg['subc_len'] = actual.shape[0]
         return data.T
 

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -27,7 +27,7 @@ def load_gifti(f, cfg, return_tr=True):
     """ Load gifti array. """
     f_gif = nib.load(f)
     data = np.vstack([arr.data for arr in f_gif.darrays])
-    start_tr = [item[1] for item in cfg.get('skip_tr') if re.match(item[0], f, re.IGNORECASE)][0]
+    start_tr = [item[1] if re.match(item[0], f, re.IGNORECASE) else 0 for item in cfg.get('skip_tr')][0]
     tr = float(f_gif.darrays[0].get_metadata()['TimeStep'])
     if return_tr:
         return data[start_tr:,:], tr
@@ -98,7 +98,7 @@ def load_and_split_cifti(cifti, indices_file, cfg, left_id=None, right_id=None, 
     datvol = nib.load(cifti)
     tr = datvol.header.get_axis(0)[1]
     dat = np.asanyarray(datvol.dataobj)
-    start_tr = [item[1] for item in cfg.get('skip_tr') if re.match(item[0], cifti, re.IGNORECASE)][0]
+    start_tr = [item[1] if re.match(item[0], cifti, re.IGNORECASE) else 0 for item in cfg.get('skip_tr')][0]
     if mode == 'all' or mode == 'surface':
         # Populate left and right hemisphere.
         l, r, = dat[:, lidxs], dat[:, ridxs]

--- a/pybest/utils.py
+++ b/pybest/utils.py
@@ -129,19 +129,30 @@ def load_and_split_cifti(cifti, indices_file, left_id=None, right_id=None, subc_
         s = np.moveaxis(s, 0, -1)
 
     if mode == 'subcortex' and return_tr==True:
-        return s, tr
+        actual, pos, zdat = get_valid_voxels(s[:, :, :, 2:])
+        return actual.T, pos, zdat, tr
 
     elif mode == 'subcortex' and return_tr==False:
-        return s
+        actual, pos, zdat = get_valid_voxels(s[:, :, :, 2:])
+        return actual.T, pos, zdat
 
     elif mode=='all' and return_tr==True:
         data = np.vstack([l, r])
-        return data.T[2:,:], s, tr
+        actual, pos, zdat = get_valid_voxels(s[:,:,:,2:])
+        return data.T[2:,:], actual.T, pos, zdat, tr
 
 
     else:
         data = np.vstack([l, r])
         return data.T[2:,:], s
+
+
+def get_valid_voxels(data):
+    stds=np.std(data,axis=-1)
+    positions=np.where(stds!=0)
+    zdat=np.zeros_like(stds)
+    actual=data[stds!=0]
+    return actual,positions,zdat
 
 
 def argmax_regularized(data, axis=0, percent=5):


### PR DESCRIPTION
- Option to read CIFTI files: click.option --iscifti ['y','n'], default 'n' and click.option --mode ['surface', 'subcortex', 'all'], default 'surface'.
- Option to skip TRs: click.option --skip-tr , nargs=2 and multiple possible --> --skip-tr 'file' 2 --skip-tr 'other file' 1
- Option to filter confounds: click.option --confounds-filter or -cf [str], works with regex and multiple possible --> -cf conf1 -cf conf2